### PR TITLE
Provide a minimal LHAPDF container

### DIFF
--- a/.github/workflows/python-poetry-tests.yml
+++ b/.github/workflows/python-poetry-tests.yml
@@ -13,6 +13,11 @@ on:
         required: false
         description: >
           Extras to be installed, in poetry format (e.g. "-E extra1 extra2")
+      container-image:
+        type: string
+        required: false
+        description: >
+          Docker container image to be used
     secrets:
       codecov-token:
         required: false
@@ -23,6 +28,8 @@ jobs:
   test:
     name: 🔬 Test (🐍 ${{ inputs.python-version }})
     runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.container-image }}
 
     steps:
       - uses: actions/checkout@v2

--- a/containers/lhapdf/Containerfile
+++ b/containers/lhapdf/Containerfile
@@ -40,6 +40,7 @@ RUN /bin/bash -c "lhapdf install NNPDF40_nnlo_as_01180 \
                                  ATLASpdf21_T1 \
                                  CT18NNLO \
                                  HERAPDF20_NNLO_EIG \
-                                 MSHT20nnlo_as118"
+                                 MSHT20nnlo_as118 \
+                                 PDF4LHC21_mc"
 
 ENTRYPOINT /bin/bash

--- a/containers/lhapdf/Containerfile
+++ b/containers/lhapdf/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.11
+FROM docker.io/python:3.10
 
 # create a dedicated user
 RUN /bin/bash -c "apt update; \
@@ -12,7 +12,7 @@ WORKDIR $HOME
 
 RUN /bin/bash -c "pip install numpy"
 
-COPY --chown=me lhapdf $HOME/lhapdf
+COPY --chown=me packages/lhapdf $HOME/lhapdf
 
 ENV PREFIX=$HOME/.local
 ENV PATH=$PATH:$HOME/.local/bin
@@ -21,7 +21,7 @@ RUN /bin/bash -c "cd lhapdf; sh install.sh"
 
 # --------------------------------------------------------- #
 
-FROM docker.io/python:3.11-slim
+FROM docker.io/python:3.10-slim
 
 RUN /bin/bash -c "useradd -m me"
 
@@ -29,8 +29,17 @@ USER me
 ENV HOME=/home/me
 WORKDIR $HOME
 
+ENV PATH=$PATH:$HOME/.local/bin
 ENV LD_LIBRARY_PATH=$HOME/.local/lib
 
 # COPY --from=0 /usr/lib/x86_64-linux-gnu/libquadmath* /usr/lib/x86_64-linux-gnu/
 # COPY --from=0 /usr/lib/x86_64-linux-gnu/libgfortran* /usr/lib/x86_64-linux-gnu/
-COPY --from=0 /home/dis/.local/ $HOME/.local
+COPY --from=0 /home/me/.local/ $HOME/.local
+RUN /bin/bash -c "lhapdf install NNPDF40_nnlo_as_01180 \
+                                 ABMP16_5_nnlo \
+                                 ATLASpdf21_T1 \
+                                 CT18NNLO \
+                                 HERAPDF20_NNLO_EIG \
+                                 MSHT20nnlo_as118"
+
+ENTRYPOINT /bin/bash

--- a/containers/lhapdf/Containerfile
+++ b/containers/lhapdf/Containerfile
@@ -1,0 +1,36 @@
+FROM docker.io/python:3.11
+
+# create a dedicated user
+RUN /bin/bash -c "apt update; \
+                  apt install -y wget patch autoconf libtool g++ make"
+
+RUN /bin/bash -c "useradd -m me"
+
+USER me
+ENV HOME=/home/me
+WORKDIR $HOME
+
+RUN /bin/bash -c "pip install numpy"
+
+COPY --chown=me lhapdf $HOME/lhapdf
+
+ENV PREFIX=$HOME/.local
+ENV PATH=$PATH:$HOME/.local/bin
+
+RUN /bin/bash -c "cd lhapdf; sh install.sh"
+
+# --------------------------------------------------------- #
+
+FROM docker.io/python:3.11-slim
+
+RUN /bin/bash -c "useradd -m me"
+
+USER me
+ENV HOME=/home/me
+WORKDIR $HOME
+
+ENV LD_LIBRARY_PATH=$HOME/.local/lib
+
+# COPY --from=0 /usr/lib/x86_64-linux-gnu/libquadmath* /usr/lib/x86_64-linux-gnu/
+# COPY --from=0 /usr/lib/x86_64-linux-gnu/libgfortran* /usr/lib/x86_64-linux-gnu/
+COPY --from=0 /home/dis/.local/ $HOME/.local

--- a/containers/lhapdf/build.sh
+++ b/containers/lhapdf/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+pushd ../..
+podman build -t ghcr.io/n3pdf/lhapdf -f $(dirs -lp | head -2 | tail -1)/Containerfile .
+popd

--- a/containers/lhapdf/build.sh
+++ b/containers/lhapdf/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 pushd ../..
-podman build -t ghcr.io/n3pdf/lhapdf -f $(dirs -lp | head -2 | tail -1)/Containerfile .
+podman build -t ghcr.io/n3pdf/lhapdf -f $(dirs -l -p | head -2 | tail -1)/Containerfile .
 popd

--- a/packages/lhapdf/README.md
+++ b/packages/lhapdf/README.md
@@ -1,0 +1,6 @@
+# LHAPDF6
+
+If you experience some errors, like those reported in
+[LHAPDF#13](https://gitlab.com/hepcedar/lhapdf/-/issues/13), make sure to
+install Cython in your current environment (the one in which you are running the
+installation).

--- a/packages/lhapdf/clean.sh
+++ b/packages/lhapdf/clean.sh
@@ -1,0 +1,5 @@
+# import variables
+. $(dirname $0)/variables.sh
+
+rm -rf $TARBALL
+rm -rf $SRC_DIR

--- a/packages/lhapdf/download.sh
+++ b/packages/lhapdf/download.sh
@@ -1,0 +1,4 @@
+URL=$1
+TARBALL=$2
+
+wget $URL -O $TARBALL

--- a/packages/lhapdf/install.sh
+++ b/packages/lhapdf/install.sh
@@ -1,0 +1,31 @@
+# early exit if errors occur
+set -e
+
+INSTALLER_DIR=$(realpath $(dirname $0))
+
+# import variables
+. $INSTALLER_DIR/variables.sh
+
+# download the code
+sh $INSTALLER_DIR/download.sh $URL $TARBALL
+
+# extract code
+tar -xvzf $TARBALL
+cd $SRC_DIR
+
+# reconfigure
+autoreconf -f -i
+# if PREFIX is set use it, otherwise do the default
+if [ -z $PREFIX ]; then
+  PYTHON=$(which python3) ./configure
+else
+  echo "Installing in $PREFIX"
+  PYTHON=$(which python3) ./configure --prefix=$PREFIX
+fi
+
+touch wrappers/python/lhapdf.pyx
+
+# reset, compile, and install (includes python interface)
+make clean
+make -j
+make install

--- a/packages/lhapdf/variables.sh
+++ b/packages/lhapdf/variables.sh
@@ -1,0 +1,4 @@
+VERSION=6.5.3
+URL="https://lhapdf.hepforge.org/downloads/?f=LHAPDF-$VERSION.tar.gz"
+TARBALL="LHAPDF-$VERSION.tar.gz"
+SRC_DIR="LHAPDF-$VERSION"


### PR DESCRIPTION
For other projects sake, here I provide a minimal LHAPDF container, with the library and Python package pre-installed.
The container is published at:

https://github.com/N3PDF/workflows/pkgs/container/lhapdf

It already contains a few common PDF sets pre-installed, with a possibly unopinionated (though small) selection:
https://github.com/N3PDF/workflows/blob/4a3f927ceef7b6df797bf02f1d333c41a58fd934/containers/lhapdf/Containerfile#L38-L44